### PR TITLE
[client/config] Add the /api path to the base url in config.ts

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -69,7 +69,7 @@
         "ts-node": "^10.9.2",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
-        "vite": "^6.0.5"
+        "vite": "^6.2.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8775,9 +8775,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.1.tgz",
-      "integrity": "sha512-n2GnqDb6XPhlt9B8olZPrgMD/es/Nd1RdChF6CBD/fHW6pUyUTt2sQW2fPRX5GiD9XEa6+8A6A4f2vT6pSsE7Q==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -71,6 +71,6 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^6.0.5"
+    "vite": "^6.2.3"
   }
 }


### PR DESCRIPTION
This change will break the .env file for any one developing the client locally. 
@abwael 

Use this in .env: 
VITE_SERVER_URL=https://api.expertbridge.duckdns.org
... // other variables 

