### PR TITLE
Make the GetProfileById in the server allows anonymous

### DIFF
--- a/server/ExpertBridge.Api/Controllers/ProfilesController.cs
+++ b/server/ExpertBridge.Api/Controllers/ProfilesController.cs
@@ -1,9 +1,3 @@
-//// Licensed to the .NET Foundation under one or more agreements.
-//// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Security.Claims;
-using ExpertBridge.Api.Core;
-using ExpertBridge.Api.Core.Interfaces.Services;
 using ExpertBridge.Api.Data.DatabaseContexts;
 using ExpertBridge.Api.Helpers;
 using ExpertBridge.Api.Models;
@@ -33,40 +27,34 @@ public class ProfilesController : ControllerBase
     public async Task<ProfileResponse> GetProfile()
     {
         var user = await _authHelper.GetCurrentUserAsync(User);
-
-        if (user == null)
-        {
-            throw new UnauthorizedException();
-        }
+        if (user == null) throw new UnauthorizedException();
 
         var profile = await _dbContext.Profiles
+            .AsNoTracking()
             .Where(p => p.UserId == user.Id)
             .Include(p => p.User)
             .SelectProfileResponseFromProfile()
             .FirstOrDefaultAsync();
 
         if (profile == null)
-        {
             throw new ProfileNotFoundException($"User[{user.Id}] Profile was not found");
-        }
 
         return profile;
     }
 
+    [AllowAnonymous]
     [HttpGet("{id}")]
     public async Task<ProfileResponse> GetProfile(string id)
     {
-        var user = await _authHelper.GetCurrentUserAsync(User);
-        if (user == null) throw new UnauthorizedException();
-
         var profile = await _dbContext.Profiles
+            .AsNoTracking()
             .Where(p => p.Id == id)
             .Include(p => p.User)
             .SelectProfileResponseFromProfile()
             .FirstOrDefaultAsync();
 
         if (profile == null)
-            throw new ProfileNotFoundException($"User[{user.Id}] Profile was not found");
+            throw new ProfileNotFoundException($"Profile with id={id} was not found");
 
         return profile;
     }


### PR DESCRIPTION
This pull request includes updates to the `ProfilesController` in the `ExpertBridge.Api` project, focusing on improving code readability, optimizing database queries, and modifying the behavior of the `GetProfile` methods. Below are the most important changes:

### Code readability and formatting:

* Combined single-line `if` statements for null checks into a more compact format to improve code readability.

### Database query optimization:

* Added the `.AsNoTracking()` method to database queries in both `GetProfile` methods to improve performance by disabling entity tracking for read-only operations.

### Behavior modification:

* Removed the user authentication check in the `GetProfile(string id)` method and added the `[AllowAnonymous]` attribute, allowing unauthenticated users to access profiles by ID.

### Code cleanup:

* Removed unused `using` directives and comments at the top of the file for a cleaner codebase.