### PR TITLE
Fixed a bug in the protected route component

### DIFF
--- a/client/src/routes/ProtectedRoute.tsx
+++ b/client/src/routes/ProtectedRoute.tsx
@@ -49,11 +49,6 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
     }
   }, [authUser, appUser, signOut, navigate]);
 
-  // ⛔️ Not logged in, redirect to login
-  if (!loginLoading && !isLoggedIn) {
-    return <Navigate to="/login" replace />;
-  }
-
   // ⏳ Still verifying auth state
   if (loginLoading) {
     return <div>Loading...</div>;

--- a/client/src/views/components/ui/skeleton.tsx
+++ b/client/src/views/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/util/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/client/src/views/pages/profile/MyProfilePage.tsx
+++ b/client/src/views/pages/profile/MyProfilePage.tsx
@@ -3,9 +3,11 @@ import { Button } from "@/views/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/views/components/ui/tabs";
 import { Pencil } from "lucide-react";
 import { Badge } from "@/views/components/ui/badge";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Separator } from "@/views/components/ui/separator";
-import defaultProfile from "../../../assets/Profile-pic/ProfilePic.svg"
+import defaultProfile from "../../../assets/Profile-pic/ProfilePic.svg";
+import { Skeleton } from "@/views/components/ui/skeleton";
+import toast from "react-hot-toast";
 
 const MyProfilePage = () => {
 	const { data: profile, isLoading, error } = useGetCurrentUserProfileQuery();

--- a/client/src/views/pages/profile/UserProfilePage.tsx
+++ b/client/src/views/pages/profile/UserProfilePage.tsx
@@ -23,7 +23,7 @@ const UserProfilePage = () => {
 	// Check if the requested profile is the current user's profile
 	useEffect(() => {
 		if (userId && authUser && appUser && userId === appUser.id) {
-			navigate("/profile");
+			navigate("/profile", { replace: true });
 		}
 	}, [userId, authUser, navigate, appUser]);
 


### PR DESCRIPTION
Fixed a bug in the protected route component, a small bug in the redirection between the UserProfilePage and the MyProfilePage, and added a new skeleton UI component to be used later

# Description
This pull request introduces several updates to the frontend codebase, including the addition of a reusable `Skeleton` component for loading states, improvements to navigation behavior, and minor code cleanups. Below are the most important changes grouped by theme:

### Component Enhancements:
* Added a new `Skeleton` component in `client/src/views/components/ui/skeleton.tsx` to provide a reusable animated placeholder for loading states. This component uses the `cn` utility for dynamic class names.

### Navigation Improvements:
* Updated the `navigate` function in `UserProfilePage` to include the `replace: true` option, ensuring that navigation to the profile page does not add an entry to the browser's history stack.

### Code Cleanup:
* Removed the redirect logic from `ProtectedRoute` for unauthenticated users, simplifying the component's behavior.
* Added `useEffect` and `toast` imports to `MyProfilePage` for handling side effects and notifications, respectively.