### PR TITLE
Add endpoints to retrieve votes for posts and comments by profile

### DIFF
--- a/server/ExpertBridge.Api/Controllers/CommentsController.cs
+++ b/server/ExpertBridge.Api/Controllers/CommentsController.cs
@@ -156,6 +156,33 @@ public class CommentsController(
             .ToListAsync();
     }
 
+    [AllowAnonymous]
+    [HttpGet]
+    [Route("/api/profiles/{profileId}/[controller]/votes")]
+    public async Task<List<GetCommentVotesResponse>> GetAllUpvotedPostsByProfileId([FromRoute] string profileId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(profileId, nameof(profileId));
+
+        var profile = await _dbContext.Profiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == profileId);
+        if (profile is null)
+            throw new ProfileNotFoundException($"Profile with id={profileId} was not found");
+
+        var votes = await _dbContext.CommentVotes
+            .AsNoTracking()
+            .Select(pv => new GetCommentVotesResponse
+            {
+                IsUpvoted = pv.IsUpvote,
+                ProfileId = pv.ProfileId,
+                CommentId = pv.CommentId
+            })
+            .Where(v => v.ProfileId == profileId)
+            .ToListAsync();
+
+        return votes;
+    }
+
     [HttpPatch("{commentId}")]
     public async Task<IActionResult> Patch([FromRoute] string commentId, [FromBody] PatchCommentRequest request)
     {

--- a/server/ExpertBridge.Api/Controllers/PostsController.cs
+++ b/server/ExpertBridge.Api/Controllers/PostsController.cs
@@ -95,6 +95,52 @@ public class PostsController : ControllerBase
             .ToListAsync();
     }
 
+    [AllowAnonymous]
+    [HttpGet]
+    [Route("/api/profiles/{profileId}/posts")]
+    public async Task<List<PostResponse>> GetAllByProfileId([FromRoute] string profileId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(profileId, nameof(profileId));
+
+        var profile = await _dbContext.Profiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == profileId);
+        if (profile is null)
+            throw new ProfileNotFoundException($"Profile with id={profileId} was not found");
+
+        return await _dbContext.Posts
+            .FullyPopulatedPostQuery(p => p.AuthorId == profileId)
+            .SelectPostResponseFromFullPost(profileId)
+            .ToListAsync();
+    }
+
+    [AllowAnonymous]
+    [HttpGet]
+    [Route("/api/profiles/{profileId}/[controller]/votes")]
+    public async Task<List<GetPostVotesResponse>> GetAllUpvotedPostsByProfileId([FromRoute] string profileId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(profileId, nameof(profileId));
+
+        var profile = await _dbContext.Profiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == profileId);
+        if (profile is null)
+            throw new ProfileNotFoundException($"Profile with id={profileId} was not found");
+
+        var votes = await _dbContext.PostVotes
+            .AsNoTracking()
+            .Select(pv => new GetPostVotesResponse
+            {
+                IsUpvoted = pv.IsUpvote,
+                ProfileId = pv.ProfileId,
+                PostId = pv.PostId
+            })
+            .Where(v => v.ProfileId == profileId)
+            .ToListAsync();
+
+        return votes;
+    }
+
     /// <summary>
     ///     Create a new post.
     /// </summary>

--- a/server/ExpertBridge.Api/Responses/GetCommentVotesResponse.cs
+++ b/server/ExpertBridge.Api/Responses/GetCommentVotesResponse.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ExpertBridge.Api.Responses;
+
+public class GetCommentVotesResponse
+{
+    public string CommentId { get; set; } = string.Empty;
+    public string ProfileId { get; set; } = string.Empty;
+    public bool IsUpvoted { get; set; }
+}

--- a/server/ExpertBridge.Api/Responses/GetPostVotesResponse.cs
+++ b/server/ExpertBridge.Api/Responses/GetPostVotesResponse.cs
@@ -1,0 +1,8 @@
+namespace ExpertBridge.Api.Responses;
+
+public class GetPostVotesResponse
+{
+    public string PostId { get; set; } = string.Empty;
+    public string ProfileId { get; set; } = string.Empty;
+    public bool IsUpvoted { get; set; }
+}


### PR DESCRIPTION
# Description

This pull request introduces new API endpoints for retrieving posts and votes associated with a specific profile, along with corresponding response models. The changes enhance the functionality of the `CommentsController` and `PostsController` by adding endpoints to fetch upvoted items and posts by profile ID.

### New API Endpoints

* [`CommentsController.cs`](diffhunk://#diff-1a2f0a6b39d9ff1c2c015b8095bd5e9b6e42b71f1c2d626a7107b0d08c0c3c24R159-R185): Added a new endpoint `GetAllUpvotedPostsByProfileId` to fetch all upvoted comments for a specific profile. This includes validation for the profile ID and throws a `ProfileNotFoundException` if the profile does not exist.
* `PostsController.cs`: Added two new endpoints:
  - [`GetAllByProfileId`](diffhunk://#diff-c0baaca54d1bec5aa3b1cff1396455d8e99ec0323ca266442961990f9867b4fdR98-R143): Fetches all posts authored by a specific profile.
  - [`GetAllUpvotedPostsByProfileId`](diffhunk://#diff-c0baaca54d1bec5aa3b1cff1396455d8e99ec0323ca266442961990f9867b4fdR98-R143): Fetches all upvoted posts for a specific profile, with similar validation and exception handling as the comments endpoint.

### Response Models

* [`GetCommentVotesResponse.cs`](diffhunk://#diff-e53bf6dabffda7c3a9f340aa7e7985db322ba672f71ae524b69da5480680b0f6R1-R11): Introduced a new response model for upvoted comments, including `CommentId`, `ProfileId`, and `IsUpvoted` properties.
* [`GetPostVotesResponse.cs`](diffhunk://#diff-c86784659f11ddaf6815bee168da7cbd7fde9487cd593dfdb5066fc9b057f1adR1-R8): Introduced a new response model for upvoted posts, including `PostId`, `ProfileId`, and `IsUpvoted` properties.