### PR TITLE
[client/UI]: Add profile-specific post and comment cards

### DIFF
--- a/client/src/views/components/common/comments/ProfileCommentCard.tsx
+++ b/client/src/views/components/common/comments/ProfileCommentCard.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Comment } from "@/features/comments/types";
+import { ThumbUp, ThumbDown } from "@mui/icons-material";
+import TimeAgo from "../../custom/TimeAgo";
+import defaultProfile from "../../../../assets/Profile-pic/ProfilePic.svg";
+
+interface ProfileCommentCardProps {
+  comment: Comment;
+  postTitle?: string;
+}
+
+const ProfileCommentCard: React.FC<ProfileCommentCardProps> = ({ comment, postTitle }) => {
+  const netVotes = comment.upvotes - comment.downvotes;
+
+  return (
+    <div className="flex flex-col gap-3 p-3 border rounded-lg bg-white">
+      {postTitle && (
+        <div className="mb-2 text-sm text-gray-500">
+          <span className="font-semibold">On Post: </span>
+          <Link 
+            to={`/feed/${comment.postId}`}
+            className="hover:text-blue-600 hover:underline"
+          >
+            {postTitle}
+          </Link>
+        </div>
+      )}
+      
+      {/* Comment Author */}
+      <div className="flex items-center space-x-3">
+        {comment.author?.profilePictureUrl ? 
+          <img
+            src={comment.author.profilePictureUrl}
+            alt="Comment Author"
+            width={30}
+            height={30}
+            className="rounded-full"
+          />
+        :
+          <img 
+            src={defaultProfile}
+            alt="Comment Author"
+            width={30}
+            height={30}
+            className="rounded-full"
+          />
+        }
+        <div>
+          {/* Name */}
+          <h4 className="text-sm font-semibold">
+            {comment.author.firstName + ' ' + comment.author.lastName}
+          </h4>
+          {/* Date of creation */}
+          <p className="text-xs text-gray-500">
+            <TimeAgo timestamp={comment.createdAt} />
+          </p>
+        </div>
+      </div>
+
+      {/* Comment Content */}
+      <div className="w-full break-words">
+        <p className="text-gray-700 whitespace-pre-wrap">{comment.content}</p>
+      </div>
+
+      {/* Vote Display */}
+      <div className="flex items-center space-x-3">
+        <div className="flex items-center text-gray-500">
+          <span className={`font-medium ${netVotes > 0 ? 'text-green-600' : netVotes < 0 ? 'text-red-600' : ''}`}>
+            {netVotes > 0 ? '+' : ''}{netVotes}
+          </span>
+          <span className="ml-1 text-xs text-gray-500">votes</span>
+        </div>
+        
+        {/* View post link */}
+        <Link to={`/feed/${comment.postId}`} className="text-xs text-blue-600 hover:underline ml-auto">
+          View Discussion
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCommentCard;

--- a/client/src/views/components/common/posts/ProfilePostCard.tsx
+++ b/client/src/views/components/common/posts/ProfilePostCard.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Post } from "@/features/posts/types";
+import { MessageCircle, ArrowBigUp, ArrowBigDown } from "lucide-react";
+import { Button } from "@/views/components/ui/button";
+import TimeAgo from "../../custom/TimeAgo";
+import defaultProfile from "../../../../assets/Profile-pic/ProfilePic.svg";
+
+interface ProfilePostCardProps {
+  post: Post;
+}
+
+const ProfilePostCard: React.FC<ProfilePostCardProps> = ({ post }) => {
+  const totalCommentsNumber = post.comments;
+  const netVotes = post.upvotes - post.downvotes;
+  
+  return (
+    <div className="flex flex-col gap-3 bg-white shadow-md rounded-lg p-4 border border-gray-200">
+      {/* Author Info */}
+      <div className="flex items-center space-x-3">
+        <Link to={`/profile/${post.author.id}`}>
+          {post.author.profilePictureUrl ? (
+            <img
+              src={post.author.profilePictureUrl}
+              width={40}
+              height={40}
+              className="rounded-full"
+            />
+          ) : (
+            <img
+              src={defaultProfile}
+              width={40}
+              height={40}
+              className="rounded-full"
+            />
+          )}
+        </Link>
+        <div className="flex w-full justify-between">
+          <div>
+            <Link to={`/profile/${post.author.id}`}>
+              <h3 className="text-md font-semibold">
+                {post.author.firstName + " " + post.author.lastName}
+              </h3>
+            </Link>
+            <div className="flex justify-between items-center text-sm text-gray-500">
+              <span>
+                <TimeAgo timestamp={post.createdAt} />
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Post Title */}
+      <div className="break-words">
+        <h2 className="text-lg font-bold text-gray-700 whitespace-pre-wrap">
+          {post.title}
+        </h2>
+      </div>
+
+      {/* Post Content */}
+      <div className="break-words">
+        <p className="text-gray-600 whitespace-pre-wrap line-clamp-3">
+          {post.content}
+        </p>
+      </div>
+
+      {/* Post Metadata */}
+      {/* Tags */}
+      {post.postTags?.length > 0 && (
+        <div className="flex space-x-2">
+          {post.postTags.map((tag: any, index: number) => (
+            <span
+              key={index}
+              className="text-xs bg-gray-200 px-2 py-1 rounded-full"
+            >
+              {tag.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="flex justify-between items-center mt-2">
+        <div className="flex space-x-4">
+          {/* Votes Display */}
+          <div className="flex items-center gap-1 text-gray-500">
+            <div className="flex items-center">
+              {netVotes >= 0 ? (
+                <ArrowBigUp className="text-gray-500 w-5 h-5" />
+              ) : (
+                <ArrowBigDown className="text-gray-500 w-5 h-5" />
+              )}
+              <span className={`ml-1 ${netVotes < 0 ? 'text-red-500' : 'text-gray-500'}`}>
+                {Math.abs(netVotes)}
+              </span>
+            </div>
+          </div>
+          
+          {/* Comments */}
+          <div className="flex items-center gap-1 text-gray-500">
+            <MessageCircle className="w-5 h-5" />
+            <span>{totalCommentsNumber}</span>
+          </div>
+        </div>
+
+        {/* View Button */}
+        <Button 
+          asChild
+          variant="outline" 
+          size="sm"
+        >
+          <Link to={`/feed/${post.id}`}>
+            View Post
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePostCard;

--- a/client/src/views/pages/profile/MyProfilePage.tsx
+++ b/client/src/views/pages/profile/MyProfilePage.tsx
@@ -14,6 +14,8 @@ import { useGetCommentsByUserIdQuery } from "@/features/comments/commentsSlice";
 import PostCard from "@/views/components/common/posts/PostCard";
 import CommentCard from "@/views/components/common/comments/CommentCard";
 import useIsUserLoggedIn from "@/hooks/useIsUserLoggedIn";
+import ProfilePostCard from "@/views/components/common/posts/ProfilePostCard";
+import ProfileCommentCard from "@/views/components/common/comments/ProfileCommentCard";
 
 
 const MyProfilePage = () => {
@@ -250,45 +252,37 @@ const MyProfilePage = () => {
   							</TabsList>
   
   							{/* Latest Questions (Posts) Tab Content */}
-  							<TabsContent value="questions" className="space-y-4">
-  								{userPosts.length > 0 ? (
-  									userPosts.map((post) => (
-  										<PostCard 
-  											key={post.id} 
-  											postId={post.id} 
-  											currUserId={appUser?.id}
-  										/>
-  									))
-  								) : (
-  									<div className="text-center py-8 text-gray-500">
-  										You haven't asked any questions yet.
-  									</div>
-  								)}
-  							</TabsContent>
+                <TabsContent value="questions" className="space-y-4">
+                  {userPosts.length > 0 ? (
+                    userPosts.map((post) => (
+                      <ProfilePostCard 
+                        key={post.id} 
+                        post={post}
+                      />
+                    ))
+                  ) : (
+                    <div className="text-center py-8 text-gray-500">
+                      You haven't asked any questions yet.
+                    </div>
+                  )}
+                </TabsContent>
   
   							{/* Answered Questions (Comments) Tab Content */}
-  							<TabsContent value="answers" className="space-y-4">
-  								{userComments && userComments.length > 0 ? (
-  									userComments.map((comment) => (
-  										<div key={comment.id} className="border rounded-lg p-4 mb-4">
-  											<div className="mb-2 text-sm text-gray-500">
-  												<span className="font-semibold">On Post: </span>
-  												<a 
-  													href={`/feed/${comment.postId}`}
-  													className="hover:text-blue-600 hover:underline"
-  												>
-  													{getPostTitleById(comment.postId)}
-  												</a>
-  											</div>
-  											<CommentCard comment={comment} />
-  										</div>
-  									))
-  								) : (
-  									<div className="text-center py-8 text-gray-500">
-  										You haven't answered any questions yet.
-  									</div>
-  								)}
-  							</TabsContent>
+                <TabsContent value="answers" className="space-y-4">
+                  {userComments && userComments.length > 0 ? (
+                    userComments.map((comment) => (
+                      <ProfileCommentCard 
+                        key={comment.id} 
+                        comment={comment}
+                        postTitle={getPostTitleById(comment.postId)}
+                      />
+                    ))
+                  ) : (
+                    <div className="text-center py-8 text-gray-500">
+                      You haven't answered any questions yet.
+                    </div>
+                  )}
+                </TabsContent>
   						</Tabs>
   					)}
   				</div>

--- a/client/src/views/pages/profile/UserProfilePage.tsx
+++ b/client/src/views/pages/profile/UserProfilePage.tsx
@@ -15,6 +15,8 @@ import CommentCard from "@/views/components/common/comments/CommentCard";
 import { useAppSelector } from "@/app/hooks";
 import { selectAllPosts, useGetPostsQuery } from "@/features/posts/postsSlice";
 import { useGetCommentsByUserIdQuery } from "@/features/comments/commentsSlice";
+import ProfilePostCard from "@/views/components/common/posts/ProfilePostCard";
+import ProfileCommentCard from "@/views/components/common/comments/ProfileCommentCard";
 
 const UserProfilePage = () => {
 	const { userId } = useParams<{ userId: string }>();
@@ -264,10 +266,9 @@ const UserProfilePage = () => {
                 <TabsContent value="questions" className="space-y-4">
                   {userPosts.length > 0 ? (
                     userPosts.map((post) => (
-                      <PostCard 
+                      <ProfilePostCard 
                         key={post.id} 
-                        postId={post.id} 
-                        currUserId={appUser?.id}
+                        post={post}
                       />
                     ))
                   ) : (
@@ -281,18 +282,11 @@ const UserProfilePage = () => {
                 <TabsContent value="answers" className="space-y-4">
                   {userComments && userComments.length > 0 ? (
                     userComments.map((comment) => (
-                      <div key={comment.id} className="border rounded-lg p-4 mb-4">
-                        <div className="mb-2 text-sm text-gray-500">
-                          <span className="font-semibold">On Post: </span>
-                          <a 
-                            href={`/feed/${comment.postId}`}
-                            className="hover:text-blue-600 hover:underline"
-                          >
-                            {getPostTitleById(comment.postId)}
-                          </a>
-                        </div>
-                        <CommentCard comment={comment} />
-                      </div>
+                      <ProfileCommentCard 
+                        key={comment.id} 
+                        comment={comment}
+                        postTitle={getPostTitleById(comment.postId)}
+                      />
                     ))
                   ) : (
                     <div className="text-center py-8 text-gray-500">


### PR DESCRIPTION
# Description
This pull request introduces two new reusable components, `ProfilePostCard` and `ProfileCommentCard`, to enhance the display of posts and comments on user profile pages. It also replaces existing implementations with these new components in the `MyProfilePage` and `UserProfilePage` components for improved code reusability and maintainability.

### New Components Added:
* **`ProfilePostCard`**: A reusable card component for displaying user posts with metadata like author information, post content, tags, votes, and comments.
* **`ProfileCommentCard`**: A reusable card component for displaying user comments, including the associated post title, author details, comment content, and vote count.

### Integration of New Components:
* **`MyProfilePage`**:
  - Replaced `PostCard` with `ProfilePostCard` for rendering user posts.
  - Replaced `CommentCard` and custom markup with `ProfileCommentCard` for rendering user comments.
  - Imported the new components.

* **`UserProfilePage`**:
  - Replaced `PostCard` with `ProfilePostCard` for rendering user posts.
  - Replaced `CommentCard` and custom markup with `ProfileCommentCard` for rendering user comments.
  - Imported the new components.