### PR TITLE
[api/refactor]: Move query classes to ExpertBridge.Core Project

### DIFF
--- a/server/ExpertBridge.Api/Controllers/CommentsController.cs
+++ b/server/ExpertBridge.Api/Controllers/CommentsController.cs
@@ -11,7 +11,7 @@ using ExpertBridge.Api.Helpers;
 using ExpertBridge.Api.Models.IPC;
 using ExpertBridge.Api.Services;
 using ExpertBridge.Api.Settings;
-using ExpertBridge.Data.Queries;
+using ExpertBridge.Core.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/server/ExpertBridge.Api/Controllers/NotificationsController.cs
+++ b/server/ExpertBridge.Api/Controllers/NotificationsController.cs
@@ -2,7 +2,7 @@
 using ExpertBridge.Core.Responses;
 using ExpertBridge.Data.DatabaseContexts;
 using ExpertBridge.Api.Helpers;
-using ExpertBridge.Data.Queries;
+using ExpertBridge.Core.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/server/ExpertBridge.Api/Controllers/PostsController.cs
+++ b/server/ExpertBridge.Api/Controllers/PostsController.cs
@@ -11,7 +11,7 @@ using ExpertBridge.Data.DatabaseContexts;
 using ExpertBridge.Api.Helpers;
 using ExpertBridge.Api.Models.IPC;
 using ExpertBridge.Api.Settings;
-using ExpertBridge.Data.Queries;
+using ExpertBridge.Core.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/server/ExpertBridge.Api/Controllers/ProfilesController.cs
+++ b/server/ExpertBridge.Api/Controllers/ProfilesController.cs
@@ -5,7 +5,7 @@ using ExpertBridge.Data.DatabaseContexts;
 using ExpertBridge.Api.Helpers;
 using ExpertBridge.Api.Services;
 using ExpertBridge.Api.Settings;
-using ExpertBridge.Data.Queries;
+using ExpertBridge.Core.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/server/ExpertBridge.Core/Queries/CommentQueries.cs
+++ b/server/ExpertBridge.Core/Queries/CommentQueries.cs
@@ -3,7 +3,7 @@ using ExpertBridge.Core.Entities.Comments;
 using ExpertBridge.Core.Responses;
 using Microsoft.EntityFrameworkCore;
 
-namespace ExpertBridge.Data.Queries
+namespace ExpertBridge.Core.Queries
 {
     public static class CommentQueries
     {

--- a/server/ExpertBridge.Core/Queries/MediaObjectQueries.cs
+++ b/server/ExpertBridge.Core/Queries/MediaObjectQueries.cs
@@ -2,7 +2,7 @@
 using ExpertBridge.Core.Responses;
 using Microsoft.EntityFrameworkCore;
 
-namespace ExpertBridge.Data.Queries
+namespace ExpertBridge.Core.Queries
 {
     public static class MediaObjectQueries
     {

--- a/server/ExpertBridge.Core/Queries/NotificationQueries.cs
+++ b/server/ExpertBridge.Core/Queries/NotificationQueries.cs
@@ -4,7 +4,7 @@
 using ExpertBridge.Core.Entities.Notifications;
 using ExpertBridge.Core.Responses;
 
-namespace ExpertBridge.Data.Queries
+namespace ExpertBridge.Core.Queries
 {
     public static class NotificationQueries
     {

--- a/server/ExpertBridge.Core/Queries/PostQueries.cs
+++ b/server/ExpertBridge.Core/Queries/PostQueries.cs
@@ -3,7 +3,7 @@ using ExpertBridge.Core.Entities.Posts;
 using ExpertBridge.Core.Responses;
 using Microsoft.EntityFrameworkCore;
 
-namespace ExpertBridge.Data.Queries
+namespace ExpertBridge.Core.Queries
 {
     public static class PostQueries
     {

--- a/server/ExpertBridge.Core/Queries/ProfileQueries.cs
+++ b/server/ExpertBridge.Core/Queries/ProfileQueries.cs
@@ -3,7 +3,7 @@ using ExpertBridge.Core.Entities.Profiles;
 using ExpertBridge.Core.Responses;
 using Microsoft.EntityFrameworkCore;
 
-namespace ExpertBridge.Data.Queries
+namespace ExpertBridge.Core.Queries
 {
     public static class ProfileQueries
     {


### PR DESCRIPTION
# Description

Moved query classes from the Api namespace to the Core namespace for improved organization and separation of concerns. Updated relevant controller imports to reflect the namespace changes.
