### PR TITLE
Add periodic worker for cleaning up old notifications

### DIFF
--- a/server/ExpertBridge.Api/BackgroundServices/Handlers/UserInterestsUpdatedHandlerWorker.cs
+++ b/server/ExpertBridge.Api/BackgroundServices/Handlers/UserInterestsUpdatedHandlerWorker.cs
@@ -44,11 +44,13 @@ namespace ExpertBridge.Api.BackgroundServices.Handlers
                     .AsNoTracking()
                     .Include(ui => ui.Tag)
                     .Where(ui => ui.ProfileId == message.UserProfileId)
-                    .Select(ui => $"[{ui.Tag.EnglishName} - {ui.Tag.ArabicName} - {ui.Tag.Description}] ");
+                    .Select(ui => $"[{ui.Tag.EnglishName} {ui.Tag.ArabicName} {ui.Tag.Description}] ");
 
                 var text = new StringBuilder();
                 foreach (var ui in userInterests)
+                {
                     text.Append(ui);
+                }
 
                 var embedding = await embeddingService.GenerateEmbedding(text.ToString());
 

--- a/server/ExpertBridge.Api/BackgroundServices/PeriodicJobs/CleanUpNotificationsPeriodicWorker.cs
+++ b/server/ExpertBridge.Api/BackgroundServices/PeriodicJobs/CleanUpNotificationsPeriodicWorker.cs
@@ -1,0 +1,51 @@
+using ExpertBridge.Data.DatabaseContexts;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace ExpertBridge.Api.BackgroundServices.PeriodicJobs;
+
+public sealed class CleanUpNotificationsPeriodicWorker : PeriodicWorker<CleanUpNotificationsPeriodicWorker>
+{
+
+    private readonly IServiceProvider _services;
+    private readonly ILogger<CleanUpNotificationsPeriodicWorker> _logger;
+    private readonly int TimeIntervalForNotificationCleanupInDays;
+
+    public CleanUpNotificationsPeriodicWorker(
+    IServiceProvider services,
+            ILogger<CleanUpNotificationsPeriodicWorker> logger)
+            : base(4, nameof(CleanUpNotificationsPeriodicWorker), logger)
+    {
+        _services = services;
+        _logger = logger;
+        TimeIntervalForNotificationCleanupInDays = -30;
+    }
+
+    protected override async Task ExecuteInternalAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            using var scope = _services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<ExpertBridgeDbContext>();
+
+            // Using ExecuteDeleteAsync for bulk deletion is more efficient than fetching and deleting individually:
+            // It executes as a single SQL DELETE statement directly on the database server (avoiding multiple round trips)
+            // and avoids loading potentially thousands of notifications into memory.
+            var numNotificationsDeleted = await dbContext.Notifications
+                .Where(n => n.CreatedAt < DateTime.UtcNow.AddDays(TimeIntervalForNotificationCleanupInDays))
+                .ExecuteDeleteAsync(cancellationToken: stoppingToken);
+
+            // _logger.LogInformation("Deleted {numNotificationsDeleted} notifications older than 30 days",
+            //     numNotificationsDeleted);
+            Log.Information("Deleted {numNotificationsDeleted} notifications older than 30 days",
+                numNotificationsDeleted);
+        }
+        catch (InvalidOperationException e)
+        {
+            // _logger.LogError(e, "An error occurred while executing the periodic worker {name}, {message}",
+            //     nameof(CleanUpNotificationsPeriodicWorker), e.Message);
+            Log.Error(e, "An error occurred while executing the periodic worker {name}, {message}",
+                nameof(CleanUpNotificationsPeriodicWorker), e.Message);
+        }
+    }
+}

--- a/server/ExpertBridge.Api/BackgroundServices/PeriodicJobs/PeriodicWorker.cs
+++ b/server/ExpertBridge.Api/BackgroundServices/PeriodicJobs/PeriodicWorker.cs
@@ -1,10 +1,7 @@
 ﻿// Licensed to the.NET Foundation under one or more agreements.
 // The.NET Foundation licenses this file to you under the MIT license.
 
-using ExpertBridge.Api.Models.IPC;
-using ExpertBridge.Data.DatabaseContexts;
 using Serilog;
-using System.Threading.Channels;
 
 namespace ExpertBridge.Api.BackgroundServices.PeriodicJobs
 {
@@ -15,7 +12,7 @@ namespace ExpertBridge.Api.BackgroundServices.PeriodicJobs
         private readonly ILogger<TWorker> _logger;
 
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="PeriodicWorker{TWorker}"/> class.
         /// </summary>
         /// <param name="startDelay">Start delay for the implementor in hours</param>
         /// <param name="logger"></param>

--- a/server/ExpertBridge.Api/Extensions/BackgroundWorkers.cs
+++ b/server/ExpertBridge.Api/Extensions/BackgroundWorkers.cs
@@ -35,6 +35,7 @@ public static class BackgroundWorkers
             .AddHostedService<InappropriatePostDetectionHandlerWorker>()
             .AddHostedService<InappropriateCommentDetectionHandlerWorker>()
             .AddHostedService<UserInterestsTagsProcessingHandlerWorker>()
+            .AddHostedService<CleanUpNotificationsPeriodicWorker>()
             ;
 
         return builder;


### PR DESCRIPTION
# Description

Introduced `CleanUpNotificationsPeriodicWorker` to handle deletion of notifications older than 30 days using efficient bulk delete operations. Registered the worker in the background services to ensure periodic execution, improving data cleanup processes. Minor refactoring and logging adjustments are included.

TAKE INTO CONSIDERATION THAT THE WORKER DELETE ALL THE NOTIFICATIONS OLDER THAN 1 MONTH ONLY
IT DOESN'T CARE WHETHER THE NOTIFICATION HAS BEEN READ OR NOT, THIS MAYBE NEEDS ANOTHER PR TO DO IT.

Fixes #289 