### PR TITLE
chore: Update Dockerfile to use aspnet runtime instead of runtime base image

### DIFF
--- a/server/ExpertBridge.Worker/Dockerfile
+++ b/server/ExpertBridge.Worker/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 USER $APP_UID
 WORKDIR /ExpertBridgeWorker
 


### PR DESCRIPTION
This pull request updates the base image used in the `server/ExpertBridge.Worker/Dockerfile` to ensure the correct runtime environment for the application. The change switches from the generic .NET runtime to the ASP.NET runtime, which is more appropriate for web applications.

Dockerfile update:

* Changed the base image from `mcr.microsoft.com/dotnet/runtime:9.0` to `mcr.microsoft.com/dotnet/aspnet:9.0` in `server/ExpertBridge.Worker/Dockerfile` to provide the necessary ASP.NET dependencies for the worker service.